### PR TITLE
Hide enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "convey"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Pascal Hertleif <killercup@gmail.com>"]
 description = "A Rust create for outputting information and log messages for humans and machines"
 license = "Apache-2.0 OR MIT"
@@ -25,5 +25,5 @@ crossbeam-channel = "0.2.6"
 proptest = "0.8.7"
 assert_fs = "0.9.0"
 predicates = "0.9.0"
-convey_derive = { version = "0.1", path = "convey_derive" }
+convey_derive = { version = "0.2", path = "convey_derive" }
 rand = "0.5.5"

--- a/convey_derive/Cargo.toml
+++ b/convey_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "convey_derive"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Katharina Fey <kookie@spacekookie.de>", "Pascal Hertleif <killercup@gmail.com>"]
 description = "A Rust create for outputting information and log messages for humans and machines"
 license = "Apache-2.0 OR MIT"
@@ -14,6 +14,6 @@ syn = "0.15"
 quote = "0.6"
 
 [dev-dependencies]
-convey = { version = "0.1", path = ".." }
+convey = { version = "0.2", path = ".." }
 serde = "1.0.79"
 serde_derive = "1.0.79"


### PR DESCRIPTION
Wrap Error and Target enums in structs to hide their variants and internal structure in public interface.