### PR TITLE
allow the user to type alias Result in their code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ script:
 
 matrix:
   include:
-  - rust: 1.31.1
+  - rust: 1.38.0
     env: CLIPPY=YESPLEASE
     before_script: rustup component add clippy-preview
     script: cargo clippy --all-targets --all -- -D warnings
-  - rust: 1.31.1
+  - rust: 1.38.0
     env: RUSTFMT=YESPLEASE
     before_script: rustup component add rustfmt-preview
     script: cargo fmt --all -- --check

--- a/src/human.rs
+++ b/src/human.rs
@@ -269,11 +269,13 @@ mod test_helper {
         pub fn target(&self) -> Target {
             Target::human(self.formatter())
         }
+    }
 
-        pub fn to_string(&self) -> String {
+    impl ::std::fmt::Display for TestTarget {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
             let target = self.buffer.0.clone();
             let buffer = target.read().unwrap();
-            String::from_utf8_lossy(buffer.as_slice()).to_string()
+            write!(f, "{}", String::from_utf8_lossy(buffer.as_slice()))
         }
     }
 }

--- a/src/human.rs
+++ b/src/human.rs
@@ -200,12 +200,12 @@ enum Response {
 #[macro_export]
 macro_rules! render_for_humans {
     ($this:ident -> []) => {
-        fn render_for_humans(&self, fmt: &mut $crate::human::Formatter) -> Result<(), $crate::Error> {
+        fn render_for_humans(&self, fmt: &mut $crate::human::Formatter) -> ::std::result::Result<(), $crate::Error> {
             Ok(())
         }
     };
     ($self:ident -> [$($item:expr,)*]) => {
-        fn render_for_humans(&$self, fmt: &mut $crate::human::Formatter) -> Result<(), $crate::Error> {
+        fn render_for_humans(&$self, fmt: &mut $crate::human::Formatter) -> ::std::result::Result<(), $crate::Error> {
             let span = $crate::span!([ $( $item, )* ]);
             span.render_for_humans(fmt)?;
             Ok(())

--- a/src/json.rs
+++ b/src/json.rs
@@ -279,11 +279,13 @@ mod test_helper {
         pub fn target(&self) -> Target {
             Target::json(self.formatter())
         }
+    }
 
-        pub fn to_string(&self) -> String {
+    impl ::std::fmt::Display for TestTarget {
+        fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
             let target = self.buffer.0.clone();
             let buffer = target.read().unwrap();
-            String::from_utf8_lossy(buffer.as_slice()).to_string()
+            write!(f, "{}", String::from_utf8_lossy(buffer.as_slice()))
         }
     }
 }

--- a/src/json.rs
+++ b/src/json.rs
@@ -212,7 +212,7 @@ enum Response {
 #[macro_export]
 macro_rules! render_json {
     () => {
-        fn render_json(&self, fmt: &mut $crate::json::Formatter) -> Result<(), $crate::Error> {
+        fn render_json(&self, fmt: &mut $crate::json::Formatter) -> ::std::result::Result<(), $crate::Error> {
             fmt.write(self)?;
             Ok(())
         }


### PR DESCRIPTION
Instead of generating functions that assume that Result is unaliased,
explicitly reference the ::std::result::Result so that end users can
have type aliases for Result that assume a specific error type (like
std::io::Result does).